### PR TITLE
Fix deprecated conversion warning

### DIFF
--- a/neopixelringclock60uno/neopixelringclock60uno.ino
+++ b/neopixelringclock60uno/neopixelringclock60uno.ino
@@ -64,8 +64,8 @@ void setup () {
 void loop () {
 
 
-  char* colon = ":"; // static characters save a bit
-  char* slash = "/"; // of memory
+  char const * colon = ":"; // static characters save a bit
+  char const * slash = "/"; // of memory
 
   // get time
   Clock = RTC.now(); // get the RTC time


### PR DESCRIPTION
Fix for "warning: deprecated conversion from string constant to ‘char_’" error. Any functions into which you pass string literals should use 'char const *' as the type instead of 'char_'.  This warning was being displayed in Arduino IDE 1.6.9.
